### PR TITLE
Remove mention of adding LS as reviewers.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,8 +10,5 @@
 
 ## A reference to a related issue in your repository (if applicable)
 
-## @mentions of the person or team responsible for reviewing proposed changes (At least 2 people)
-- 
-
 ## Checklist
 - [ ] I can confirm that my changes are working as intended

--- a/onboarding_documents/submissions.md
+++ b/onboarding_documents/submissions.md
@@ -31,11 +31,10 @@ This guide is designed to standardize the submission and evaluation process for 
         ![](./images/pr_NOT_DO_creation.png)
         ![](./images/pr_branch_to_main.png)
     - **PR Description:** Your pull request must include a detailed description of what you aimed to accomplish, the approach taken, and whether it has been tested. Please read [Guidelines for Pull Request Descriptions](#guidelines-for-pull-request-descriptions).
-    - **PR reviewers:** Please add your technical facilitator and learning support staff to the list of reviewers.
-        ![](./images/reviewers.png)
     - **Public Repository:** Ensure that your repository is public and accessible to others. If your repository is private, technical facilitators and learning support staff will not be able to access it and therefore will not be able to evaluate your submissions. To do this, go to your repository and check for the "public" badge next to the repository name.
         ![](./images/public_repo.png)
     - **PR Link:** Please visit your pull request on another browser or in your browsers private mode to ensure that it is accessible by everyone. [Example Pull Request Submission Link](#example-pull-request-submission-link).
+    - **Do not tag your teaching team in the pull request**: We will be able to find your submissions if you have followed the instructions above!
     
 
 ## Guidelines for Pull Request Descriptions


### PR DESCRIPTION
- adding LS as reviewer results in notification overload for the teaching team
- teaching team needs to manually accept collaborator invites for every single repo for this to work, making this impractical


Review requested:
@danielrazavi