### PR TITLE
Add a new section "Restoring main branch to the original state"

### DIFF
--- a/onboarding_documents/submissions.md
+++ b/onboarding_documents/submissions.md
@@ -222,6 +222,67 @@ Over time, the original repository might receive updates or changes from the cou
 >
 > Be sure to carefully review the changes so you don’t accidentally overwrite your completed work. After resolving, you can commit the changes and sync your fork with the latest updates.
 
+## Restoring main branch to the original state
+
+Accidental changes to the main branch can occur for several reasons:
+
+1. Mistakenly committing changes directly to main instead of creating a feature or assignment branch.
+2. Accidentally merging incomplete or experimental branches into main without proper review or testing.
+3. Errors during the pull request process, such as targeting the wrong branch or not resolving conflicts properly.
+4. Misunderstanding the purpose of keeping `main` as the stable, deployable branch, leading to direct edits or merges.
+
+In a real project, the `main` branch represents the stable, deployable version of the project. Feature development, bug fixes, and experiments are done in separate branches to ensure `main` remains clean and reliable.
+
+To update your `main` branch so it no longer includes your assignment changes, follow one of the options listed below.
+
+The commands listed below are for restoring main branch of `shell` repository to the original state.
+
+**Option 1** 
+
+(If you want to reset the `main` branch to match the `upstream` version)
+
+1. Add upstream to remote: `git remote add upstream https://github.com/UofT-DSI/shell.git`
+
+2. Check if upstream is set correctly: `git remote -v`
+3. Switch to `main` and reset it to upstream: `git switch -C main upstream/main`
+4. Push your changes to the `main` on Github: `git push --force origin main`
+   
+**Option 2**
+
+(If you want to reset only assignment.sh file)
+
+1. Change to assignments dir and download the file
+   
+```
+curl -Lo assignment.sh https://github.com/UofT-DSI/shell/raw/refs/heads/main/02_activities/assignments/assignment.sh
+```
+
+2. Add, commit and push to your github `main` branch:
+   
+```
+git add assignment.sh
+git commit -m "updating assignment.sh to upstream/main version"
+git push origin main
+```
+
+**Option 3**
+
+ (Another way to reset just the assignment.sh file in `main`)
+
+1. Add upstream remote:
+`git remote add upstream https://github.com/UofT-DSI/shell.git`
+2. Check if upstream is set correctly: `git remote -v`
+2. Fetch updates from upstream: `git fetch upstream`
+3. Switch to local main: `git checkout main`
+4. Change to 'assignments' dir and get the file from upstream branch:
+ `git checkout upstream/main -- assignment.sh`
+5. Add, commit and push to your github main:
+```
+git add assignment.sh
+git commit -m "updating assignment.sh to upstream/main version"
+git push origin main
+```
+
 ## Resources
 
 * [How to Fork a Repo](https://youtu.be/H-8kzcQWJ7U)

--- a/onboarding_documents/submissions.md
+++ b/onboarding_documents/submissions.md
@@ -231,7 +231,8 @@ In a real project, the `main` branch represents the stable, deployable version o
 3. Errors during the pull request process, such as targeting the wrong branch or not resolving conflicts properly.
 4. Misunderstanding the purpose of keeping `main` as the stable, deployable branch, leading to direct edits or merges.
 
-To update your `main` branch so that it no longer includes your `assignment` changes, follow one of the options listed below. The commands listed below are for restoring the `main` branch of `shell` repository to its original state.
+For example, if you want to restore the `main` branch of `shell` repository to its original 
+state so that it no longer includes the changes that were made to the `assignment` branch, follow one of the options listed below.
 
 ### **Option 1** 
 

--- a/onboarding_documents/submissions.md
+++ b/onboarding_documents/submissions.md
@@ -224,14 +224,12 @@ Over time, the original repository might receive updates or changes from the cou
 
 ## Restoring main branch to the original state
 
-Accidental changes to the main branch can occur for several reasons:
+In a real project, the `main` branch represents the stable, deployable version of the project. Feature development, bug fixes, and experiments are done in separate branches to ensure `main` remains clean and reliable. Accidental changes to the `main` branch can occur for several reasons:
 
 1. Mistakenly committing changes directly to main instead of creating a feature or assignment branch.
 2. Accidentally merging incomplete or experimental branches into main without proper review or testing.
 3. Errors during the pull request process, such as targeting the wrong branch or not resolving conflicts properly.
 4. Misunderstanding the purpose of keeping `main` as the stable, deployable branch, leading to direct edits or merges.
-
-In a real project, the `main` branch represents the stable, deployable version of the project. Feature development, bug fixes, and experiments are done in separate branches to ensure `main` remains clean and reliable.
 
 To update your `main` branch so that it no longer includes your `assignment` changes, follow one of the options listed below. The commands listed below are for restoring the `main` branch of `shell` repository to its original state.
 

--- a/onboarding_documents/submissions.md
+++ b/onboarding_documents/submissions.md
@@ -233,13 +233,11 @@ Accidental changes to the main branch can occur for several reasons:
 
 In a real project, the `main` branch represents the stable, deployable version of the project. Feature development, bug fixes, and experiments are done in separate branches to ensure `main` remains clean and reliable.
 
-To update your `main` branch so it no longer includes your assignment changes, follow one of the options listed below.
+To update your `main` branch so it no longer includes your assignment changes, follow one of the options listed below. The commands listed below are for restoring the `main` branch of `shell` repository to its original state.
 
-The commands listed below are for restoring main branch of `shell` repository to the original state.
+### **Option 1** 
 
-**Option 1** 
-
-(If you want to reset the `main` branch to match the `upstream` version)
+If you want to reset the `main` branch to match the `upstream` version:
 
 1. Add upstream to remote: `git remote add upstream https://github.com/UofT-DSI/shell.git`
 
@@ -247,9 +245,9 @@ The commands listed below are for restoring main branch of `shell` repository to
 3. Switch to `main` and reset it to upstream: `git switch -C main upstream/main`
 4. Push your changes to the `main` on Github: `git push --force origin main`
    
-**Option 2**
+### **Option 2**
 
-(If you want to reset only assignment.sh file)
+If you want to reset only assignment.sh file:
 
 1. Change to assignments dir and download the file
    
@@ -257,7 +255,7 @@ The commands listed below are for restoring main branch of `shell` repository to
 curl -Lo assignment.sh https://github.com/UofT-DSI/shell/raw/refs/heads/main/02_activities/assignments/assignment.sh
 ```
 
-2. Add, commit and push to your github `main` branch:
+2. Add, commit and push to your Github `main` branch:
    
 ```
 git add assignment.sh
@@ -265,9 +263,9 @@ git commit -m "updating assignment.sh to upstream/main version"
 git push origin main
 ```
 
-**Option 3**
+### **Option 3**
 
- (Another way to reset just the assignment.sh file in `main`)
+ Another way to reset just the assignment.sh file in `main`:
 
 1. Add upstream remote:
 `git remote add upstream https://github.com/UofT-DSI/shell.git`

--- a/onboarding_documents/submissions.md
+++ b/onboarding_documents/submissions.md
@@ -233,11 +233,11 @@ Accidental changes to the main branch can occur for several reasons:
 
 In a real project, the `main` branch represents the stable, deployable version of the project. Feature development, bug fixes, and experiments are done in separate branches to ensure `main` remains clean and reliable.
 
-To update your `main` branch so it no longer includes your assignment changes, follow one of the options listed below. The commands listed below are for restoring the `main` branch of `shell` repository to its original state.
+To update your `main` branch so that it no longer includes your `assignment` changes, follow one of the options listed below. The commands listed below are for restoring the `main` branch of `shell` repository to its original state.
 
 ### **Option 1** 
 
-If you want to reset the `main` branch to match the `upstream` version:
+If you want to reset the whole `main` branch to match the `upstream` version:
 
 1. Add upstream to remote: `git remote add upstream https://github.com/UofT-DSI/shell.git`
 
@@ -247,7 +247,7 @@ If you want to reset the `main` branch to match the `upstream` version:
    
 ### **Option 2**
 
-If you want to reset only assignment.sh file:
+If you want to reset only `assignment.sh` file in `main`:
 
 1. Change to assignments dir and download the file
    
@@ -265,7 +265,7 @@ git push origin main
 
 ### **Option 3**
 
- Another way to reset just the assignment.sh file in `main`:
+ Another way to reset just the `assignment.sh` file in `main`:
 
 1. Add upstream remote:
 `git remote add upstream https://github.com/UofT-DSI/shell.git`
@@ -274,7 +274,7 @@ git push origin main
 3. Switch to local main: `git checkout main`
 4. Change to 'assignments' dir and get the file from upstream branch:
  `git checkout upstream/main -- assignment.sh`
-5. Add, commit and push to your github main:
+5. Add, commit and push to your Github main:
 ```
 git add assignment.sh
 git commit -m "updating assignment.sh to upstream/main version"


### PR DESCRIPTION
## What changes are you trying to make? (e.g. Adding or removing code, refactoring existing code, adding reports)
Adding a new section in the documentation with title "Restoring main branch to the original state". 
(Reference: https://uoft-dsi-certificates.slack.com/archives/C07VC4XUJ11/p1732893423564619 thread on Slack)

## What did you learn from the changes you have made?
For the 'shell' assignment with Cohort 5, we noticed that many participants made changes to assignment.sh in the main branch as well as the assignment branch. As a result, the main branch diverged from the version in the forked repository. This created problems with creating pull request or in running the autograder.  The solutions suggested by Learning support during that time were documented in the shell scratchpad. There was request made by the cohort to add it to some place permanent. Therefore, it is being added to this .md file.

## Was there another approach you were thinking about making? If so, what approach(es) were you thinking of?
None

## Were there any challenges? If so, what issue(s) did you face? How did you overcome it?
Following the steps listed in this section solved the issue for many participants.

## How were these changes tested?
Tested on VSCode preview window and on the browser.

## A reference to a related issue in your repository (if applicable)
None

## Checklist
- [x] I can confirm that my changes are working as intended
